### PR TITLE
Added compatibility with password protected redis caches

### DIFF
--- a/config/secrets/server.json.template
+++ b/config/secrets/server.json.template
@@ -9,7 +9,8 @@
   },
   "redis": {
     "host": "localhost",
-    "port": 6379
+    "port": 6379,
+    "password": "password"
   },
   "statsd": {
     "host": "localhost",

--- a/core/app.py
+++ b/core/app.py
@@ -31,13 +31,11 @@ def init_db():
 
 
 def init_cache():
-    redis_password = config.secrets.server('redis.password')
-    redis_password = None if redis_password == 'password' else redis_password
     return redis.StrictRedis(
         host=config.secrets.server('redis.host'),
         port=config.secrets.server('redis.port'),
         db=0,
-        password=redis_password,
+        password=config.secrets.server('redis.password'),
     )
 
 

--- a/core/app.py
+++ b/core/app.py
@@ -31,11 +31,13 @@ def init_db():
 
 
 def init_cache():
+    redis_password = config.secrets.server('redis.password')
+    redis_password = None if redis_password == 'password' else redis_password
     return redis.StrictRedis(
         host=config.secrets.server('redis.host'),
         port=config.secrets.server('redis.port'),
         db=0,
-        password=config.secrets.server('redis.password'),
+        password=redis_password,
     )
 
 

--- a/core/app.py
+++ b/core/app.py
@@ -35,6 +35,7 @@ def init_cache():
         host=config.secrets.server('redis.host'),
         port=config.secrets.server('redis.port'),
         db=0,
+        password=config.secrets.server('redis.password'),
     )
 
 


### PR DESCRIPTION
My server had a password protected redis cache, so linkr wouldn't work.

Currently, the application assumes that the redis cache being used doesn't have a password. Though this is a fair assumption, there may be cases where the cache might be secured with a password. 

I've added an extra field to the server's secrets json, and feeding it to the StrictRedis constructor.