### PR TITLE
Switch to mysqlclient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ Jinja2==2.8
 MarkupSafe==0.23
 mccabe==0.5.3
 mock==2.0.0
-mysqlclient==1.3.13
+mysqlclient==mysqlclient==1.4.1
 nose==1.3.7
 pbr==2.0.0
 pycodestyle==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ Jinja2==2.8
 MarkupSafe==0.23
 mccabe==0.5.3
 mock==2.0.0
-MySQL-python==1.2.5
+mysqlclient==1.3.13
 nose==1.3.7
 pbr==2.0.0
 pycodestyle==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ Jinja2==2.8
 MarkupSafe==0.23
 mccabe==0.5.3
 mock==2.0.0
-mysqlclient==mysqlclient==1.4.1
+mysqlclient==1.4.1
 nose==1.3.7
 pbr==2.0.0
 pycodestyle==2.2.0


### PR DESCRIPTION
Currently the library [MySQL-Python](https://github.com/farcepest/MySQLdb1) is in use. The last commit is 5 years ago and in general it has some quirks. 
I run on an error while trying to get this running on an alpine docker container.

I solved this issue by switching to the fork [mysqlclient](https://github.com/PyMySQL/mysqlclient-python) which is still alive and since it's a fork it is easily exchangeable.

So switching has a few benefits:
- Bugs will still be fixed
- Previous bugs as mentioned earlier are already fixed
- It is runnable on alpine and therefore easy to use for Docker

And I'm sure there are more benefits from it.